### PR TITLE
Add ability to save state

### DIFF
--- a/_zplugin
+++ b/_zplugin
@@ -12,6 +12,7 @@ commands=(
     load:'load plugin'
     unload:'unload plugin'
     snippet:"source local or remote file (-f: force - don't use cache)"
+    save:"save the current list of snippets and plugins (-: output to stdout)"
     update:'update plugin (Git)'
     update-all:'update all plugins (Git)'
     status:'status for plugin (Git)'
@@ -156,6 +157,12 @@ case $state in
             snippet)
                 typeset -a list
                 list=( "-f" )
+                _files || _wanted soptions expl "Options" \
+                    compadd "$@" -a - list
+                ;;
+            save)
+                typeset -a list
+                list=( "-" )
                 _files || _wanted soptions expl "Options" \
                     compadd "$@" -a - list
                 ;;

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1330,7 +1330,7 @@ ZPLG_ZLE_HOOKS_LIST=(
 # Removes a given loadable plugin or snipet from the order stack.
 # Really only used during load of such a thing as dupes would not be pleasant.
 -zplg-remove-from-order-stack() {
-    local what="$1" name="$2" mode="$3"  # mode is not required at this time.
+    local what="$1" mode="$2" name="$3"  # mode is not required at this time.
 
     # Remove existing first since we keep unloaded ones around (commented).
     # All that we care about here is that the type/what is the same, since it's
@@ -1344,7 +1344,7 @@ ZPLG_ZLE_HOOKS_LIST=(
 # First thing it does is remove any items of the same type and name as the one
 # being added to avoid dupes.
 -zplg-append-to-order-stack() {
-    local what="$1" name="$2" mode="$3"
+    local what="$1" mode="$2" name="$3"
     -zplg-remove-from-order-stack "$@"  # cheater
     ZPLG_ORDER+=("$what $mode $name")
 }

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1335,7 +1335,7 @@ ZPLG_ZLE_HOOKS_LIST=(
     # Remove existing first since we keep unloaded ones around (commented).
     # All that we care about here is that the type/what is the same, since it's
     # exclusive.
-    local pat="${what} * ${name}"
+    local pat="${(q)what} * ${(q)name}"
     local oidx="${ZPLG_ORDER[(i)$pat]}"
     ZPLG_ORDER[$oidx]=()
 }
@@ -1346,7 +1346,7 @@ ZPLG_ZLE_HOOKS_LIST=(
 -zplg-append-to-order-stack() {
     local what="$1" mode="$2" name="$3"
     -zplg-remove-from-order-stack "$@"  # cheater
-    ZPLG_ORDER+=("$what $mode $name")
+    ZPLG_ORDER+=("${(q)what} ${(q)mode} ${(q)name}")
 }
 
 # Will take uspl, uspl2, or just plugin name,

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1830,6 +1830,9 @@ ZPLG_ZLE_HOOKS_LIST=(
 
 # TODO detect second autoload?
 -zplg-register-plugin() {
+    local -a opts=()
+    zparseopts -a opts -K -D f
+
     local mode="$3"
     -zplg-any-to-user-plugin "$1" "$2"
     local user="${reply[-2]}" plugin="${reply[-1]}" uspl2="${reply[-2]}/${reply[-1]}"
@@ -1837,18 +1840,23 @@ ZPLG_ZLE_HOOKS_LIST=(
 
     if ! -zplg-exists "$user" "$plugin"; then
         ZPLG_REGISTERED_PLUGINS+=( "$uspl2" )
-    else
+    elif [ -n "${opts[(r)-f]}" ]; then
         # Allow overwrite-load, however warn about it
-        print "Warning: plugin \`$uspl2' already registered, will overwrite-load"
+        print "Warning: plugin \`$uspl2' already registered, will overwrite-load."
         ret=1
+    else
+        # We're already loaded, and we're not being forced, so it's all good.
+        print "Info: plugin \`$uspl2' already registered. If you mean to force reloading it, try \`-f' to force loading."
+        return 0
     fi
 
     # Full or light load?
     [ "$mode" = "light" ] && ZPLG_REGISTERED_STATES[$uspl2]="1" || ZPLG_REGISTERED_STATES[$uspl2]="2"
 
-    local oidx="${ZPLG_ORDER[(i)$uspl2]}"
+    local cur="${mode} ${uspl2}"
+    local oidx="${ZPLG_ORDER[(i)$cur]}"
     ZPLG_ORDER[$oidx]=()
-    ZPLG_ORDER+=("${(q)mode} ${(q)uspl2}")
+    ZPLG_ORDER+=("$cur")
 
     ZPLG_REPORTS[$uspl2]=""
     ZPLG_FUNCTIONS_BEFORE[$uspl2]=""

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -819,7 +819,7 @@ ZPLG_ZLE_HOOKS_LIST=(
         f="${(Q)f}"
 
         # Compute for elements in left column,
-        # ones that will be paded with spaces 
+        # ones that will be paded with spaces
         if (( count ++ % 2 != 0 )); then
             [ "${#f}" -gt "$longest_left" ] && longest_left="${#f}"
             cur_left_len="${#f}"
@@ -1268,7 +1268,7 @@ ZPLG_ZLE_HOOKS_LIST=(
         fi
         user="_local"
     fi
-    
+
     if [ -z "$user" ]; then
         user="_local"
     fi
@@ -1673,8 +1673,8 @@ ZPLG_ZLE_HOOKS_LIST=(
     }
 
     # All to the users - simulate OMZ directory structure (2/3)
-    [ ! -d "$ZPLG_PLUGINS_DIR/custom" ] && command mkdir "$ZPLG_PLUGINS_DIR/custom" 
-    [ ! -d "$ZPLG_PLUGINS_DIR/custom/plugins" ] && command mkdir "$ZPLG_PLUGINS_DIR/custom/plugins" 
+    [ ! -d "$ZPLG_PLUGINS_DIR/custom" ] && command mkdir "$ZPLG_PLUGINS_DIR/custom"
+    [ ! -d "$ZPLG_PLUGINS_DIR/custom/plugins" ] && command mkdir "$ZPLG_PLUGINS_DIR/custom/plugins"
 }
 
 # $1 - user---plugin, user/plugin, user (if $2 given), or plugin (if $2 empty)
@@ -1781,7 +1781,7 @@ ZPLG_ZLE_HOOKS_LIST=(
     setopt localoptions nullglob
 
     typeset -a symlinked backup_comps
-    local c cfile bkpfile 
+    local c cfile bkpfile
 
     symlinked=( "$ZPLG_COMPLETIONS_DIR"/_* )
     backup_comps=( "$ZPLG_COMPLETIONS_DIR"/[^_]* )
@@ -1927,7 +1927,7 @@ ZPLG_ZLE_HOOKS_LIST=(
     -zplg-shadow-on "$mode"
 
     # We need some state, but user wants his for his plugins
-    -zplg-restore-enter-state 
+    -zplg-restore-enter-state
     builtin source "$dname/$fname"
     # Restore our desired state for our operation
     -zplg-set-desired-shell-state
@@ -1957,7 +1957,7 @@ ZPLG_ZLE_HOOKS_LIST=(
     local fname="${first#$dname/}"
 
     print "Compiling ${ZPLG_COL[info]}$fname${ZPLG_COL[rst]}..."
-    -zplg-restore-enter-state 
+    -zplg-restore-enter-state
     zcompile "$first" || {
         print "Compilation failed. Don't worry, the plugin will work also without compilation"
         print "Consider submitting an error report to the plugin's author"
@@ -2016,7 +2016,7 @@ ZPLG_ZLE_HOOKS_LIST=(
 
     #
     # Display - resolves owner of each completion,
-    # detects if completion is disabled 
+    # detects if completion is disabled
     #
 
     integer disabled
@@ -2391,7 +2391,7 @@ ZPLG_ZLE_HOOKS_LIST=(
             print "Deleting ${ZPLG_COL[info]}range${ZPLG_COL[rst]} bindkey $sw_arr1 $sw_arr2 ${ZPLG_COL[info]}mapped to $sw_arr4${ZPLG_COL[rst]}"
             bindkey -M "$sw_arr4" -Rr "$sw_arr1"
         elif [[ "$sw_arr3" != "-M" && "$sw_arr5" = "-R" ]]; then
-            print "Deleting ${ZPLG_COL[info]}range${ZPLG_COL[rst]} bindkey $sw_arr1 $sw_arr2" 
+            print "Deleting ${ZPLG_COL[info]}range${ZPLG_COL[rst]} bindkey $sw_arr1 $sw_arr2"
             bindkey -Rr "$sw_arr1"
         elif [[ "$sw_arr3" = "-A" ]]; then
             print "Linking backup-\`main' keymap \`$sw_arr4' back to \`main'"
@@ -2571,7 +2571,7 @@ ZPLG_ZLE_HOOKS_LIST=(
         # Find variables created or modified
         for k in "${(k)elem_post[@]}"; do
             k="${(Q)k}"
-            local v1="${(Q)elem_pre[$k]}" 
+            local v1="${(Q)elem_pre[$k]}"
             local v2="${(Q)elem_post[$k]}"
 
             # "" means a variable was deleted, not created/changed

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -2857,7 +2857,9 @@ ZPLG_ZLE_HOOKS_LIST=(
     local cur state mode pre
     for cur in "${ZPLG_ORDER[@]}"; do
         # space separated: $what $mode $name
-        mode="${cur%% * *}" cur="${cur#* * }"
+        # hack off the type, it's only useful to make removals less, well, hacky.
+        cur="${cur#* }"
+        mode="${cur%% *}" cur="${cur#* }"
 
         state="${ZPLG_REGISTERED_STATES[$cur]}"
         pre="$ZPLG_NAME"

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -2857,9 +2857,10 @@ ZPLG_ZLE_HOOKS_LIST=(
     local cur state mode pre
     for cur in "${ZPLG_ORDER[@]}"; do
         # space separated: $what $mode $name
-        # hack off the type, it's only useful to make removals less, well, hacky.
-        cur="${cur#* }"
-        mode="${cur%% *}" cur="${cur#* }"
+        # since we quote on the way on, this should be fine to word split
+        cur=($=cur)
+        mode="${cur[@]:1:1}"
+        cur="${cur[@]:2:1}"
 
         state="${ZPLG_REGISTERED_STATES[$cur]}"
         pre="$ZPLG_NAME"

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1901,7 +1901,6 @@ ZPLG_ZLE_HOOKS_LIST=(
 
     # Full or light load?
     [ "$mode" = "light" ] && ZPLG_REGISTERED_STATES[$uspl2]="1" || ZPLG_REGISTERED_STATES[$uspl2]="2"
-
     -zplg-append-to-order-stack "$mode" "$uspl2"
 
     ZPLG_REPORTS[$uspl2]=""
@@ -2373,6 +2372,7 @@ ZPLG_ZLE_HOOKS_LIST=(
         -zplg-unregister-plugin "$user" "$plugin"
     else
         -zplg-load-plugin "$@"
+        -zplg-state-changed "$mode" "$user/$plugin"
     fi
 }
 
@@ -2720,8 +2720,6 @@ ZPLG_ZLE_HOOKS_LIST=(
 
     ZPLG_SNIPPETS[$url]="$filename"
 
-    -zplg-append-to-order-stack "snippet" "$url"
-
     # Change the url to point to raw github content if it isn't like that
     if (( is_no_raw_github )); then
         url="${url/\/blob\///raw/}"
@@ -2752,6 +2750,8 @@ ZPLG_ZLE_HOOKS_LIST=(
     -zplg-shadow-on "compdef"
     builtin source "$ZPLG_SNIPPETS_DIR/$local_dir/$filename"
     -zplg-shadow-off "compdef"
+
+    -zplg-state-changed "snippet" "$url"
 }
 
 # Updates given plugin

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -2447,7 +2447,7 @@ ZPLG_ZLE_HOOKS_LIST=(
         [ -z "$f" ] && continue
         f="${(Q)f}"
         print "Deleting function $f"
-        unfunction "$f"
+        unfunction -- "$f"
     done
 
     #
@@ -2536,10 +2536,10 @@ ZPLG_ZLE_HOOKS_LIST=(
 
             if [ "${opts[$k]}" = "on" ]; then
                 print "Setting option $k"
-                setopt "$k"
+                setopt -- "$k"
             else
                 print "Unsetting option $k"
-                unsetopt "$k"
+                unsetopt -- "$k"
             fi
         done
     fi
@@ -2565,13 +2565,13 @@ ZPLG_ZLE_HOOKS_LIST=(
 
         if [ "$nv_arr3" = "-s" ]; then
             print "Removing ${ZPLG_COL[info]}suffix${ZPLG_COL[rst]} alias ${nv_arr1}=${nv_arr2}"
-            unalias -s "$nv_arr1"
+            unalias -s -- "$nv_arr1"
         elif [ "$nv_arr3" = "-g" ]; then
             print "Removing ${ZPLG_COL[info]}global${ZPLG_COL[rst]} alias ${nv_arr1}=${nv_arr2}"
-            unalias "${(q)nv_arr1}"
+            unalias -- "${(q)nv_arr1}"
         else
             print "Removing alias ${nv_arr1}=${nv_arr2}"
-            unalias "$nv_arr1"
+            unalias -- "$nv_arr1"
         fi
     done
 
@@ -2682,7 +2682,7 @@ ZPLG_ZLE_HOOKS_LIST=(
                 # (didn't have a type)
                 if [ "$v1" = "\"\"" ]; then
                     print "Unsetting variable $k"
-                    unset "$k"
+                    unset -- "$k"
                 fi
             fi
         done

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -2863,7 +2863,7 @@ ZPLG_ZLE_HOOKS_LIST=(
         pre="$ZPLG_NAME"
         [[ "$state" != 0 ]] || pre="#$pre"
 
-        out+=("$pre $mode $cur")
+        out+=("${(q)pre} ${(q)mode} ${(q)cur}")
     done
 
     out="${(j.\n.)out[@]}"

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -2747,6 +2747,7 @@ ZPLG_ZLE_HOOKS_LIST=(
     fi
 
     ZPLG_SNIPPETS[$url]="$filename"
+    -zplg-append-to-order-stack "snippet" "$url"
 
     # Change the url to point to raw github content if it isn't like that
     if (( is_no_raw_github )); then

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -21,6 +21,7 @@ typeset -gaH ZPLG_ORDER
 
 # on: commit of a stateful change; right after a plugin/snippet has loaded.
 typeset -gaH ZPLG_COMMIT_HOOKS=()
+# TODO Make the above an associative array of $hook_name=("$hooks[@]}")
 
 #
 # Common needed values

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1852,6 +1852,7 @@ ZPLG_ZLE_HOOKS_LIST=(
 
 # TODO detect second autoload?
 -zplg-register-plugin() {
+    # Opts can be "handled" to this function from caller (our only one: -zplg-load)
     local -a opts=("${opts[@]}")
     zparseopts -a opts -D -K f
 
@@ -2695,7 +2696,8 @@ ZPLG_ZLE_HOOKS_LIST=(
 
     ZPLG_SNIPPETS[$url]="$filename"
 
-    -zplg-append-to-order-stack "snippet" "snippet" "$url"
+    local mode="snippet"
+    -zplg-append-to-order-stack "snippet" "$mode" "$url"
 
     # Change the url to point to raw github content if it isn't like that
     if (( is_no_raw_github )); then

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -2392,7 +2392,7 @@ ZPLG_ZLE_HOOKS_LIST=(
     set -- "$mode" "$@"
 
     -zplg-any-to-user-plugin "$2" "$3"
-    local user="${reply[-2]}" plugin="${reply[-1]}"
+    local uspl2="${reply[-2]}/${reply[-1]}" user="${reply[-2]}" plugin="${reply[-1]}"
     set -- "$mode" "$user" "$plugin" "${@:4}"
 
     -zplg-register-plugin "$@"
@@ -2400,7 +2400,7 @@ ZPLG_ZLE_HOOKS_LIST=(
         -zplg-unregister-plugin "$user" "$plugin"
     else
         -zplg-load-plugin "$@"
-        -zplg-commit "$mode" "$user/$plugin"
+        -zplg-commit "$mode" "$uspl2"
     fi
 }
 

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -2965,9 +2965,9 @@ ZPLG_ZLE_HOOKS_LIST=(
             local backupfile="${file}.last"
             print "[${0:t}]" "- File already exists: ${infoc}$file${reset_color}" >&2
             print "[${0:t}]" "- Backing it up to: ${infoc}$backupfile${reset_color}" >&2
-            cat "$file" > "$backupfile"
+            cat "$file" >| "$backupfile"
         fi
-        echo "$out" > "$file"
+        echo "$out" >| "$file"
     fi
     print "[${0:t}]" "Done!"
 }


### PR DESCRIPTION
This adds a command 'save' which saves the currently loaded list of plugins/snippets including order.

Unloaded ones are included but commented out.

I made some fixes that happened to include some "cleanup" I did as well, which might actually be a bit opinionated. Namely, the switch of argument handling to (for command-related methods) hand off positional arguments where applicable.

I have also changed the behavior of `zplugin load psprint/zsnapshot` in that if the plugin already exists it doesn't reload by default, it just skips it, unless you add a `-f`/`force` flag.

Let me know how this sits with you, interested in feedback.
