### PR TITLE
Install from git protocol to allow private repos

### DIFF
--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1803,7 +1803,7 @@ builtin setopt noaliases
         print "Downloading $REPLY..."
 
         # Return with error when any problem
-        git clone --recursive https://github.com/"$github_path" "$ZPLG_PLUGINS_DIR/${user}---${plugin}" || return 1
+        git clone --recursive git@github.com:"$github_path".git "$ZPLG_PLUGINS_DIR/${user}---${plugin}" || return 1
 
         # Install completions
         -zplg-install-completions "$user" "$plugin" "0"

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1803,7 +1803,7 @@ builtin setopt noaliases
         print "Downloading $REPLY..."
 
         # Return with error when any problem
-        git clone --recursive git@github.com:"$github_path".git "$ZPLG_PLUGINS_DIR/${user}---${plugin}" || return 1
+        git clone --recursive git://github.com/"$github_path" "$ZPLG_PLUGINS_DIR/${user}---${plugin}" || git clone --recursive git@github.com:"$github_path".git "$ZPLG_PLUGINS_DIR/${user}---${plugin}" || return 1
 
         # Install completions
         -zplg-install-completions "$user" "$plugin" "0"


### PR DESCRIPTION
in automated setup, it is much easier to have ssh configured to have github key which then allows to clone from private repo, than it is to manually enter username and password for private repo behind https. 

~~as far as i know, there are no situations where https works but git protocol (which is basically ssh) doesn't on github, so there shouldn't be any functionality loss.~~

Using just the ssh+git protocol requires the user to setup .ssh access to github and have an account, so using that exclusively doesn't work. Using the https protocol first asks the user for username and password on private repos. 

Using the git protocol first, and then git+ssh if git fails, solves this issue.