### PR TITLE
Prevent parse errors caused by aliases

### DIFF
--- a/zplugin-install.zsh
+++ b/zplugin-install.zsh
@@ -318,6 +318,9 @@ builtin source ${ZPLGM[BIN_DIR]}"/zplugin-side.zsh"
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 -zplg-compile-plugin() {
+    # Prevent parse errors from global aliases or reserved word overloading
+    setopt localoptions noaliases
+
     -zplg-any-to-user-plugin "$1" "$2"
     local user="${reply[-2]}" plugin="${reply[-1]}" first
     local plugin_dir="${${${(M)plugin:#%}:+$plugin}:-${ZPLGM[PLUGINS_DIR]}/${user}---${plugin}}"
@@ -374,7 +377,7 @@ builtin source ${ZPLGM[BIN_DIR]}"/zplugin-side.zsh"
 # supports Subversion protocol and allows to clone subdirectories.
 # This is used to provide a layer of support for Oh-My-Zsh and Prezto.
 -zplg-download-snippet() {
-    setopt localoptions extendedglob noksharrays
+    setopt localoptions extendedglob noksharrays noaliases
 
     local save_url="$1" url="$2" local_dir="$3" filename0="$4" filename="$5" update="$6"
     integer retval=0

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1,6 +1,10 @@
 # -*- mode: shell-script -*-
 # vim:ft=zsh
 
+# Global aliases and overloaded reserved words can cause parse errors
+[[ -o aliases ]] && _setopt_aliases=1
+builtin set -o no_aliases
+
 #
 # Main state variables
 #
@@ -1411,6 +1415,8 @@ builtin setopt noaliases
 # Searches for timeout tasks, executes them
 # $1 - if not empty, it's a following, not first call
 -zplg-scheduler() {
+    setopt localoptions noaliases
+
     integer __ret=$?
     [[ -n "$1" && "$1" != "burst" ]] && sched +1 "-zplg-scheduler following"
     [[ -n "$1" && "$1" != (following|burst) ]] && { local THEFD="$1"; zle -F "$THEFD"; exec {THEFD}<&-; }
@@ -1467,6 +1473,8 @@ builtin setopt noaliases
 # Main function directly exposed to user, obtains subcommand
 # and its arguments, has completion.
 zplugin() {
+    setopt localoptions noaliases
+
     [[ "$1" != "ice" ]] && {
         local -a ice
         ice=( "${(kv)ZPLG_ICE[@]}" )
@@ -1777,4 +1785,10 @@ export MANPATH=$MANPATH:$ZPFX/share/man
 # Colorize completions for commands unload, report, creinstall, cuninstall
 zstyle ':completion:*:zplugin:argument-rest:plugins' list-colors '=(#b)(*)/(*)==1;35=1;33'
 zstyle ':completion:*:zplugin:argument-rest:plugins' matcher 'r:|=** l:|=*'
+
+# Restore shell option 'aliases' if it was previously enabled
+if [[ $_setopt_aliases = 1 ]]; then
+   set -o aliases
+   builtin unset _setopt_aliases
+fi
 # }}}


### PR DESCRIPTION
Global aliases get expanded when source-ing a file.

Save current aliases shell option, then disable aliases before any non-builtins
are executed.

Restore aliases option at end if it was initially set.

Note: this PR will hide the error message in "Error messages are truncated" #59