### PR TITLE
Account for different man/MANPATH behavior on Solaris

### DIFF
--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1782,7 +1782,11 @@ ZPLG_REGISTERED_STATES[_local/zplugin]="1"
 fpath=( "${ZPLGM[COMPLETIONS_DIR]}" "${fpath[@]}" )
 
 # Set up $ZPFX
-export MANPATH=$MANPATH:$ZPFX/share/man
+if [[ $(uname -a) =~ "^SunOS.*" ]] && [[ -z $MANPATH ]]; then
+  export MANPATH=/usr/share/man:$ZPFX/share/man
+else
+  export MANPATH=$MANPATH:$ZPFX/share/man
+fi
 
 # Colorize completions for commands unload, report, creinstall, cuninstall
 zstyle ':completion:*:zplugin:argument-rest:plugins' list-colors '=(#b)(*)/(*)==1;35=1;33'


### PR DESCRIPTION
On most systems,

    export MANPATH=$MANPATH:$ZPFX/share/man

has the desired effect of adding `~/.zplugin/polaris/share/man` to the list of places where `man` can find man pages.

On Solaris 11.3 and OpenIndiana, however, when I run `man man` (for instance), I get the error

    No manual entry for man.

If I `unset MANPATH`, I can get `man` working again. From what I can tell, for Solaris, as long as `MANPATH` is empty, `man` will search in `/usr/share/man`, but adding to an empty `MANPATH` has the effect of replacing the default location.

My proposed fix simply checks on Solaris and OpenIndiana for an empty `MANPATH`; in that case, `/usr/share/man` is added to the new `MANPATH` before `$ZPFX`; if `MANPATH` is not empty, `$ZPFX` is added to what is already there.

This may be a problem on other System V OSes; perhaps an even more general workaround can be devised.