### PR TITLE
*-autoload: show full log when updating

### DIFF
--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1281,16 +1281,18 @@ ZPLGM[EXTENDED_GLOB]=""
               integer had_output=0
               local IFS=$'\n'
               command git fetch --quiet && \
-                command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset' ..FETCH_HEAD | \
+                command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset%n' ..FETCH_HEAD | \
                 while read line; do
-                  [[ -n "${line%%[[:space:]]##}" && $had_output -eq 0 ]] && {
-                      had_output=1
-                      [[ "${ICE_OPTS[opt_-q,--quiet]}" = 1 ]] && {
-                          -zplg-any-colorify-as-uspl2 "$id_as"
-                          print "\r\nUpdating plugin $REPLY"
+                  [[ -n "${line%%[[:space:]]##}" ]] && {
+                      [[ $had_output -eq 0 ]] && {
+                          had_output=1
+                          [[ "${ICE_OPTS[opt_-q,--quiet]}" = 1 ]] && {
+                              -zplg-any-colorify-as-uspl2 "$id_as"
+                              print "\r\nUpdating plugin $REPLY"
+                          }
                       }
+                      echo $line
                   }
-                  echo $line
                 done | \
                 command tee .zplugin_lstupd | \
                 command less -FRXi &


### PR DESCRIPTION
`git log --pretty` doesn't terminate with a newline unless its output is a terminal, so `read` returns nonzero on the last line.
This also prevents update-or-status from recognizing a plugin which is behind by one commit.

This commit adds a newline onto each commit line, and then strips the newlines in the `while read` loop.