### PR TITLE
GALLERY.md: P10K->ZINC

### DIFF
--- a/GALLERY.md
+++ b/GALLERY.md
@@ -101,6 +101,10 @@ zplugin light chauncey-garrett/zsh-prompt-garrett
 zplugin ice svn atload"prompt garrett"
 zplugin snippet PZT::modules/prompt
 
-zplugin ice nocompletions atclone'prompt_p10k_compile' atpull'%atclone'
-zplugin load robobenklein/p10k
+zplugin ice nocompletions atpull'prompt_zinc_compile' compile"{zinc_functions/*,segments/*,zinc.zsh}"
+zplugin load robobenklein/zinc
+# ZINC git info is already async, but if you want it even faster with gitstatus in turbo mode:
+# https://github.com/romkatv/gitstatus
+zplugin ice wait'1' atload'zinc_optional_depenency_loaded'
+zplugin load romkatv/gitstatus
 ```


### PR DESCRIPTION
Renamed the project, added support for loading optional dependencies in turbo mode.

Thanks mostly to @romkatv for reworking gitstatus to support this async usage.

If idea from #116 gets in, the prompt can be redrawn (`prompt_zinc_precmd && zle && zle .reset-prompt`) in the `afterload` ice, however it shows the wrong results if done in `atload` since it's in the plugin's dir.