### PR TITLE
Save username to git credentials on successful repository creation

### DIFF
--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -2358,6 +2358,7 @@ ZPLGM[EXTENDED_GLOB]=""
             return 1
         }
         builtin cd -q "${user}---${plugin//\//---}"
+        command git config credential.https://github.com.username "${user}"
     else
         print "${ZPLGM[col-info]}Creating local git repository${${user:+.}:-, ${ZPLGM[col-pname]}free-style, without the \"_local/\" part${ZPLGM[col-info]}.}${ZPLGM[col-rst]}"
         command mkdir "${user:+${user}---}${plugin//\//---}"


### PR DESCRIPTION
Small convenience tweak removing the need to type your GitHub username on each push.