### PR TITLE
Support uncompressed tarball (from"gh-r")

### DIFF
--- a/zplugin-install.zsh
+++ b/zplugin-install.zsh
@@ -769,6 +769,9 @@ builtin source ${ZPLGM[BIN_DIR]}"/zplugin-side.zsh"
         (*.tar.7z|*.t7z)
             -zplg-extract() { command 7z x -so "$file" | command tar -xf -; }
             ;;
+        (*.tar)
+            -zplg-extract() { command tar -xf "$file"; }
+            ;;
         (*.gz)
             -zplg-extract() { command gunzip "$file"; }
             ;;


### PR DESCRIPTION
Some github repos provide releases by uncompressed tar file.
(e.g. [cdr/sshcode/releases](https://github.com/cdr/sshcode/releases))

### Expected Behavior
```sh
$ zplugin ice from'gh-r' as'program'; zplugin load cdr/sshcode

Downloading cdr/sshcode...
(Requesting `sshcode-darwin-amd64.tar'...)
Extracting files from: `sshcode-darwin-amd64.tar'...
Successfully installed executables ("sshcode") contained in `sshcode-darwin-amd64.tar'.

$ command sshcode
Usage: sshcode [FLAGS] HOST [DIR]
...
```

### Actual Behavior
```sh
$ zplugin ice from'gh-r' as'program'; zplugin load cdr/sshcode

Downloading cdr/sshcode...
(Requesting `sshcode-darwin-amd64.tar'...)

$ command sshcode
zsh: command not found: sshcode
```
