### PR TITLE
Fix light mode in `for`-syntax

### DIFF
--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1891,7 +1891,7 @@ env-whitelist|bindkeys|module|add-fpath|fpath|run) ]] && \
                         else
                             ZPLG_SICE[${${1#https://github.com/}%%(/|//|///)}]=""
                             -zplg-submit-turbo p${ZPLG_ICE[service]:+1} \
-                                "${${${(M)+ZPLG_ICE[light]:#1}:+light}:-load}" \
+                                "${${(M)+ZPLG_ICE[light]+light}:-load}" \
                                 "${${1#https://github.com/}%%(/|//|///)}" ""
                         fi
                         __retval+=$?

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1891,7 +1891,7 @@ env-whitelist|bindkeys|module|add-fpath|fpath|run) ]] && \
                         else
                             ZPLG_SICE[${${1#https://github.com/}%%(/|//|///)}]=""
                             -zplg-submit-turbo p${ZPLG_ICE[service]:+1} \
-                                "${${(M)+ZPLG_ICE[light]+light}:-load}" \
+                                "${${+ZPLG_ICE[light]+light}:-load}" \
                                 "${${1#https://github.com/}%%(/|//|///)}" ""
                         fi
                         __retval+=$?


### PR DESCRIPTION
Line 1894 was returning load regardless of if `ZPLG_ICE[light]` was set or not. It seemed the `:#1` portion was matching every time and setting it null from my tests.

I replaced the line with `"${${(M)+ZPLG_ICE[light]+light}:-load}" \` and it seems to work correctly now. Although I am not completely familiar with zsh and the differences between what you were attempting to do and my quick fix.