### PR TITLE
Single-quote PATH and FPATH elements for Windows with MSYS2 or Cygwin

### DIFF
--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -724,17 +724,17 @@ function $f {
 
     [[ "$2" = "begin" ]] && {
             { [[ -z "${ZPLGM[PATH_BEFORE__$uspl2]}" ]] && \
-                tmp=( "${(q)path[@]}" )
+                tmp=( "${(qq)path[@]}" )
                 ZPLGM[PATH_BEFORE__$1]="${tmp[*]}"
             }
             { [[ -z "${ZPLGM[FPATH_BEFORE__$uspl2]}" ]] && \
-                tmp=( "${(q)fpath[@]}" )
+                tmp=( "${(qq)fpath[@]}" )
                 ZPLGM[FPATH_BEFORE__$1]="${tmp[*]}"
             }
     } || {
-            tmp=( "${(q)path[@]}" )
+            tmp=( "${(qq)path[@]}" )
             ZPLGM[PATH_AFTER__$1]+=" ${tmp[*]}"
-            tmp=( "${(q)fpath[@]}" )
+            tmp=( "${(qq)fpath[@]}" )
             ZPLGM[FPATH_AFTER__$1]+=" ${tmp[*]}"
     }
 } # }}}


### PR DESCRIPTION
When I run `zplg report --all` on MSYS2, for **every** plugin I have loaded I see

    PATH elements added:
    /c/Program Files (x86)/Common Files/Oracle/Java/javapath
    /c/Program Files (x86)/NVIDIA Corporation/PhysX/Common
    /c/Program Files (x86)/vim/vim80
    /c/Program Files (x86)/Windows Live/Shared

Those happen to be the elements of my Windows `PATH` that have `(x86)` in their names. On Cygwin, I similarly get

    PATH elements added:
    /cygdrive/c/Program Files (x86)/Common Files/Oracle/Java/javapath
    /cygdrive/c/Program Files (x86)/NVIDIA Corporation/PhysX/Common
    /cygdrive/c/Program Files (x86)/vim/vim80
    /cygdrive/c/Program Files (x86)/Windows Live/Shared

I tried altering the `-zplg-diff-env` function in `zplugin.zsh` so that the `PATH` and `FPATH` elements get single-quoted with the `(qq)` flag. It appears to fix the problem, but we'll have to make sure the change doesn't adversely affect any other features.

Your thoughts?