### PR TITLE
Fix updating plugins with ver-ice

### DIFF
--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1535,7 +1535,7 @@ ZPLGM[EXTENDED_GLOB]=""
                 "${arr[5]}" "plugin" "$user" "$plugin" "$id_as" "$local_dir" atpull
             done
             ZPLG_ICE=()
-        } || print "Already up to date."
+        } || [[ "${ICE_OPTS[opt_-q,--quiet]}" != 1 ]] && print "Already up to date."
 
         # Store ices to disk at update of plugin
         -zplg-store-ices "$local_dir/._zplugin" ice "" "" "" ""

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1476,7 +1476,7 @@ ZPLGM[EXTENDED_GLOB]=""
                       eval "${ZPLG_ICE[reset]:-command git reset --hard HEAD}"
                   )
                   [[ ${ice[atpull]} = "!"* ]] && -zplg-countdown "atpull" && ( (( ${+ice[nocd]} == 0 )) && { builtin cd -q "$local_dir" && -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; ((1)); } || -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; )
-				  (( !skip_pull )) && {
+		  (( !skip_pull )) && {
                   [[ -n "${ZPLG_ICE[ver]}" ]] && command git merge --no-stat "${ZPLG_ICE[ver]}" || command git pull --no-stat
                   }
                   ZPLG_ICE=()

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1476,9 +1476,7 @@ ZPLGM[EXTENDED_GLOB]=""
                       eval "${ZPLG_ICE[reset]:-command git reset --hard HEAD}"
                   )
                   [[ ${ice[atpull]} = "!"* ]] && -zplg-countdown "atpull" && ( (( ${+ice[nocd]} == 0 )) && { builtin cd -q "$local_dir" && -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; ((1)); } || -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; )
-                  (( !skip_pull )) && {
-                  [[ -n "${ZPLG_ICE[ver]}" ]] && command git merge --no-stat "${ZPLG_ICE[ver]}" || command git pull --no-stat
-                  }
+                  (( !skip_pull )) && command git "${${+ZPLG_ICE[ver]+merge}:-pull}" --no-stat ${ZPLG_ICE[ver]}
                   ZPLG_ICE=()
               }
             )

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1476,15 +1476,17 @@ ZPLGM[EXTENDED_GLOB]=""
                       eval "${ZPLG_ICE[reset]:-command git reset --hard HEAD}"
                   )
                   [[ ${ice[atpull]} = "!"* ]] && -zplg-countdown "atpull" && ( (( ${+ice[nocd]} == 0 )) && { builtin cd -q "$local_dir" && -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; ((1)); } || -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; )
+				  (( !skip_pull )) && {
+                  [[ -n "${ZPLG_ICE[ver]}" ]] && command git merge --no-stat "${ZPLG_ICE[ver]}" || command git pull --no-stat
+                  }
                   ZPLG_ICE=()
-                  (( !skip_pull )) && command git pull --no-stat
               }
             )
         }
 
         [[ -d "$local_dir/.git" ]] && \
             (  builtin cd -q "$local_dir" # || return 1 - don't return, maybe it's some hook's logic
-               command git pull --recurse-submodules
+               command git submodule update --init --recursive
             )
 
         local -a log
@@ -1535,7 +1537,7 @@ ZPLGM[EXTENDED_GLOB]=""
                 "${arr[5]}" "plugin" "$user" "$plugin" "$id_as" "$local_dir" atpull
             done
             ZPLG_ICE=()
-        }
+        } || print "Already up to date."
 
         # Store ices to disk at update of plugin
         -zplg-store-ices "$local_dir/._zplugin" ice "" "" "" ""

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1535,7 +1535,7 @@ ZPLGM[EXTENDED_GLOB]=""
                 "${arr[5]}" "plugin" "$user" "$plugin" "$id_as" "$local_dir" atpull
             done
             ZPLG_ICE=()
-        } || { [[ "${ICE_OPTS[opt_-q,--quiet]}" != 1 ]] && print "Already up to date." }
+        } || { [[ "${ICE_OPTS[opt_-q,--quiet]}" != 1 && -z "${ice[is_release]}" ]] && print "Already up to date." }
 
         # Store ices to disk at update of plugin
         -zplg-store-ices "$local_dir/._zplugin" ice "" "" "" ""

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1476,7 +1476,7 @@ ZPLGM[EXTENDED_GLOB]=""
                       eval "${ZPLG_ICE[reset]:-command git reset --hard HEAD}"
                   )
                   [[ ${ice[atpull]} = "!"* ]] && -zplg-countdown "atpull" && ( (( ${+ice[nocd]} == 0 )) && { builtin cd -q "$local_dir" && -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; ((1)); } || -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; )
-		  (( !skip_pull )) && {
+                  (( !skip_pull )) && {
                   [[ -n "${ZPLG_ICE[ver]}" ]] && command git merge --no-stat "${ZPLG_ICE[ver]}" || command git pull --no-stat
                   }
                   ZPLG_ICE=()

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1428,7 +1428,7 @@ ZPLGM[EXTENDED_GLOB]=""
               integer had_output=0
               local IFS=$'\n'
               command git fetch --quiet && \
-                command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset%n' ..FETCH_HEAD | \
+                command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset%n' .."${ice[ver]:-FETCH_HEAD}" | \
                 while read line; do
                   [[ -n "${line%%[[:space:]]##}" ]] && {
                       [[ $had_output -eq 0 ]] && {

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1535,7 +1535,7 @@ ZPLGM[EXTENDED_GLOB]=""
                 "${arr[5]}" "plugin" "$user" "$plugin" "$id_as" "$local_dir" atpull
             done
             ZPLG_ICE=()
-        } || [[ "${ICE_OPTS[opt_-q,--quiet]}" != 1 ]] && print "Already up to date."
+        } || { [[ "${ICE_OPTS[opt_-q,--quiet]}" != 1 ]] && print "Already up to date." }
 
         # Store ices to disk at update of plugin
         -zplg-store-ices "$local_dir/._zplugin" ice "" "" "" ""

--- a/zplugin-install.zsh
+++ b/zplugin-install.zsh
@@ -891,7 +891,7 @@ builtin source ${ZPLGM[BIN_DIR]}"/zplugin-side.zsh"
     local user="${reply[-2]}"
     local plugin="${reply[-1]}"
 
-    local url="https://github.com/$user/$plugin/releases/latest"
+    local url="https://github.com/$user/$plugin/releases/${ice[ver]:-latest}"
 
     local -a list
     list=( ${(@f)"$( { -zplg-download-file-stdout $url || -zplg-download-file-stdout $url 1; } 2>/dev/null | \


### PR DESCRIPTION
Use `git merge` when ver ice is present, to merge any updates. Replace `git pull --recurse-submodules` with `git submodule update --init --recursive` to only update submodules and not undo the previous fix. Add an "Already up to date." message, previously provided by the `git pull --recurse-submodules` command, if the plugin is up to date.

This fixes issue #210, let me know what you think!