### PR TITLE
${~ZPFX}/bin should be added to PATH only once

### DIFF
--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -62,7 +62,7 @@ ZPLGM[COMPLETIONS_DIR]=${~ZPLGM[COMPLETIONS_DIR]}
 ZPLGM[SNIPPETS_DIR]=${~ZPLGM[SNIPPETS_DIR]}
 ZPLGM[SERVICES_DIR]=${~ZPLGM[SERVICES_DIR]}
 export ZPFX=${~ZPFX} ZSH_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache/zplugin}"
-(( ${path[(ie)${~ZPFX}/bin]} <= ${#path} )) || path=( ${~ZPFX}/bin ${path[@]} )
+[[ -n ${path[(re)$ZPFX/bin]} ]] || path=( "$ZPFX/bin" ${path[@]} )
 
 [[ ! -d $ZSH_CACHE_DIR ]] && command mkdir -p "$ZSH_CACHE_DIR"
 [[ -n "${ZPLGM[ZCOMPDUMP_PATH]}" ]] && ZPLGM[ZCOMPDUMP_PATH]=${~ZPLGM[ZCOMPDUMP_PATH]}

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -61,7 +61,8 @@ ZPLGM[PLUGINS_DIR]=${~ZPLGM[PLUGINS_DIR]}
 ZPLGM[COMPLETIONS_DIR]=${~ZPLGM[COMPLETIONS_DIR]}
 ZPLGM[SNIPPETS_DIR]=${~ZPLGM[SNIPPETS_DIR]}
 ZPLGM[SERVICES_DIR]=${~ZPLGM[SERVICES_DIR]}
-export ZPFX=${~ZPFX} ZSH_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache/zplugin}" PATH=${~ZPFX}/bin:"$PATH"
+export ZPFX=${~ZPFX} ZSH_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache/zplugin}"
+(( path[(ie)${~ZPFX}/bin] <= $#path )) || path=( ${~ZPFX}/bin $path )
 
 [[ ! -d $ZSH_CACHE_DIR ]] && command mkdir -p "$ZSH_CACHE_DIR"
 [[ -n "${ZPLGM[ZCOMPDUMP_PATH]}" ]] && ZPLGM[ZCOMPDUMP_PATH]=${~ZPLGM[ZCOMPDUMP_PATH]}

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -62,7 +62,7 @@ ZPLGM[COMPLETIONS_DIR]=${~ZPLGM[COMPLETIONS_DIR]}
 ZPLGM[SNIPPETS_DIR]=${~ZPLGM[SNIPPETS_DIR]}
 ZPLGM[SERVICES_DIR]=${~ZPLGM[SERVICES_DIR]}
 export ZPFX=${~ZPFX} ZSH_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache/zplugin}"
-(( path[(ie)${~ZPFX}/bin] <= $#path )) || path=( ${~ZPFX}/bin $path )
+(( ${path[(ie)${~ZPFX}/bin]} <= ${#path} )) || path=( ${~ZPFX}/bin ${path[@]} )
 
 [[ ! -d $ZSH_CACHE_DIR ]] && command mkdir -p "$ZSH_CACHE_DIR"
 [[ -n "${ZPLGM[ZCOMPDUMP_PATH]}" ]] && ZPLGM[ZCOMPDUMP_PATH]=${~ZPLGM[ZCOMPDUMP_PATH]}
@@ -1459,7 +1459,7 @@ function $f {
     local id_as="$1" add_dir="$2" user="${reply[-2]}" plugin="${reply[-1]}"
     (( front )) && \
         fpath[1,0]=${${${(M)user:#%}:+$plugin}:-${ZPLGM[PLUGINS_DIR]}/${id_as//\//---}}${add_dir:+/$add_dir} || \
-        fpath+=( 
+        fpath+=(
             ${${${(M)user:#%}:+$plugin}:-${ZPLGM[PLUGINS_DIR]}/${id_as//\//---}}${add_dir:+/$add_dir}
         )
 }


### PR DESCRIPTION
As it is right now, `${~ZPFX}/bin` gets added to `PATH` even when it's already there, which can lead to `PATH`s such as

    /home/alexandros/.zplugin/polaris/bin:/home/alexandros/.zplugin/polaris/bin:/home/alexandros/.zplugin/polaris/bin:/home/alexandros/.zplugin/polaris/bin:/home/alexandros/perl5/bin:/home/alexandros/bin:/home/alexandros/.luarocks/bin:/home/alexandros/.config/composer/vendor/bin:/home/alexandros/.cabal/bin:/home/alexandros/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin

This pull request fixes the problem by checking to see if `${~ZPFX}/bin` is an element of the array `path` before adding it to `path`.