### PR TITLE
Check to make sure aliases exist before unaliasing

### DIFF
--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -927,29 +927,35 @@ ZPLGM[EXTENDED_GLOB]=""
         if [[ "$nv_arr3" = "-s" ]]; then
             if [[ -n "$nv_arr2" ]]; then
                 (( quiet )) || print "Restoring ${ZPLGM[col-info]}suffix${ZPLGM[col-rst]} alias ${nv_arr1}=${nv_arr2}"
-                unalias -s -- "$nv_arr1"
+                alias "$nv_arr1" &> /dev/null && unalias -s -- "$nv_arr1"
                 alias -s -- "${nv_arr1}=${nv_arr2}"
             else
-                (( quiet )) || print "Removing ${ZPLGM[col-info]}suffix${ZPLGM[col-rst]} alias ${nv_arr1}"
-                unalias -s -- "$nv_arr1"
+                (( quiet )) || alias "$nv_arr1" &> /dev/null && {
+                    print "Removing ${ZPLGM[col-info]}suffix${ZPLGM[col-rst]} alias ${nv_arr1}"
+                    unalias -s -- "$nv_arr1"
+                }
             fi
         elif [[ "$nv_arr3" = "-g" ]]; then
             if [[ -n "$nv_arr2" ]]; then
                 (( quiet )) || print "Restoring ${ZPLGM[col-info]}global${ZPLGM[col-rst]} alias ${nv_arr1}=${nv_arr2}"
-                unalias -g -- "$nv_arr1"
+                alias "$nv_arr1" &> /dev/null && unalias -g -- "$nv_arr1"
                 alias -g -- "${nv_arr1}=${nv_arr2}"
             else
-                (( quiet )) || print "Removing ${ZPLGM[col-info]}global${ZPLGM[col-rst]} alias ${nv_arr1}"
-                unalias -- "${(q)nv_arr1}"
+                (( quiet )) || alias "$nv_arr1" &> /dev/null && {
+                    print "Removing ${ZPLGM[col-info]}global${ZPLGM[col-rst]} alias ${nv_arr1}"
+                    unalias -- "${(q)nv_arr1}"
+                }
             fi
         else
             if [[ -n "$nv_arr2" ]]; then
                 (( quiet )) || print "Restoring alias ${nv_arr1}=${nv_arr2}"
-                unalias -- "$nv_arr1"
+                alias "$nv_arr1" &> /dev/null && unalias -- "$nv_arr1"
                 alias -- "${nv_arr1}=${nv_arr2}"
             else
-                (( quiet )) || print "Removing alias ${nv_arr1}"
-                unalias -- "$nv_arr1"
+                (( quiet )) || alias "$nv_arr1" &> /dev/null && {
+                    print "Removing alias ${nv_arr1}"
+                    unalias -- "$nv_arr1"
+                }
             fi
         fi
     done


### PR DESCRIPTION
I was getting the error message

    -zplg-unload:unalias:208: no such hash table element: z

when I ran `zplugin unload agkozak/zsh-z`. My [zsh-z](https://github.com/agkozak/zsh-z) plugin supports the [zdharma Plugin Unload Standard](https://github.com/zdharma/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc#2-unload-function), and its [unload function](https://github.com/agkozak/zsh-z/blob/ebe458409ec07c9ad10d05557a93d4b28397c0a1/zsh-z.plugin.zsh#L675-L699) unaliases its own command alias (by default `z`). I see that `zplugin` keeps track of all the aliases introduced by each plugin and tries to `unalias` them unconditionally upon `unload`.

It seems to me that it would be desirable to have `zplugin` check to see if an alias exists before trying to `unalias` it. This pull request attempts to accomplish that (and it suppresses the `Removing foo alias` message if the unaliasing does not, in fact, occur). See what you think.