### PR TITLE
Update ohmyzsh remote url

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ the new commits pulled-in in the last update.
 To use **themes** created for Oh My Zsh you might want to first source the `git` library there:
 
 ```SystemVerilog
-zplugin snippet http://github.com/robbyrussell/oh-my-zsh/raw/master/lib/git.zsh
+zplugin snippet http://github.com/ohmyzsh/ohmyzsh/raw/master/lib/git.zsh
 # Or using OMZ:: shorthand:
 zplugin snippet OMZ::lib/git.zsh
 ```

--- a/doc/Zsh.gitignore
+++ b/doc/Zsh.gitignore
@@ -15,7 +15,7 @@
 # zdharma/zshelldoc tool's files
 zsdoc/data
 
-# robbyrussell/oh-my-zsh/plugins/per-directory-history plugin's files
+# ohmyzsh/ohmyzsh/plugins/per-directory-history plugin's files
 # (when set-up to store the history in the local directory)
 .directory_history
 

--- a/doc/zplugin.1
+++ b/doc/zplugin.1
@@ -658,7 +658,7 @@ To use \fBthemes\fR created for Oh My Zsh you might want to first source the \fB
 .P
 .RS 2
 .nf
-zplugin snippet http://github.com/robbyrussell/oh-my-zsh/raw/master/lib/git.zsh
+zplugin snippet http://github.com/ohmyzsh/ohmyzsh/raw/master/lib/git.zsh
 # Or using OMZ:: shorthand:
 zplugin snippet OMZ::lib/git.zsh
 .fi

--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -84,11 +84,11 @@ typeset -gH ZPLG_CUR_PLUGIN=""
 # Parameters - ICE, {{{
 declare -gA ZPLG_1MAP ZPLG_2MAP
 ZPLG_1MAP=(
-    "OMZ::" "https://github.com/robbyrussell/oh-my-zsh/trunk/"
+    "OMZ::" "https://github.com/ohmyzsh/ohmyzsh/trunk/"
     "PZT::" "https://github.com/sorin-ionescu/prezto/trunk/"
 )
 ZPLG_2MAP=(
-    "OMZ::" "https://github.com/robbyrussell/oh-my-zsh/raw/master/"
+    "OMZ::" "https://github.com/ohmyzsh/ohmyzsh/raw/master/"
     "PZT::" "https://github.com/sorin-ionescu/prezto/raw/master/"
 )
 # }}}


### PR DESCRIPTION
The zsh framework `robbyrussell/oh-my-zsh` is now redirected to `ohmyzsh/ohmyzsh`. This pull request updates the remote url.